### PR TITLE
CSV Loader crash when there is no validation of headers

### DIFF
--- a/Load/CsvLoader.php
+++ b/Load/CsvLoader.php
@@ -186,7 +186,7 @@ class CsvLoader implements LoaderInterface
     {
         $config = $resource->getConfig();
         $useFirstRowAsHeader = $config['load']['format_options']['with_header'] && $config['load']['format_options']['validate_headers'];
-        $headers = $useFirstRowAsHeader ? $this->getFirstRow($resource, $context) : $resource->getCsvFields();
+        $headers = $useFirstRowAsHeader ? $this->getFirstRow($resource, $context) : array_keys($resource->getCsvFields());
 
         if ($useFirstRowAsHeader && (count($headers) !== count($resource->getCsvFields()) || [] !== array_diff($headers, array_keys($resource->getCsvFields())) || [] !== array_diff(array_keys($resource->getCsvFields()), $headers))) {
             throw new ImportException('The first row of the CSV file must contain the same fields as defined in the configuration');


### PR DESCRIPTION
When the configuration of your import don't validate the headers, the CSV loader crash :


```yaml
            format_options:
                with_header: true
                validate_headers: false
```

The error :
```php
In CsvLoader.php line 195:
                                                                                                                        
  [TypeError]                                                                                                           
  LePhare\Import\Load\CsvLoader::LePhare\Import\Load\{closure}(): Argument #1 ($v) must be of type string, array given  
                                                                                                                        

Exception trace:
  at /app/vendor/lephare/import/Load/CsvLoader.php:195
 LePhare\Import\Load\CsvLoader->LePhare\Import\Load\{closure}() at n/a:n
```