### PR TITLE
feat: show resource path on debug mode and when exception thrown

### DIFF
--- a/Import.php
+++ b/Import.php
@@ -196,6 +196,7 @@ class Import implements ImportInterface
         foreach ($files as $file) {
             $this->logger->debug('load resource {file}', [
                 'file' => $file->getBasename(),
+                'path' => $file->getPath(),
             ]);
             if ($this->dispatcher->hasListeners(ImportEvents::VALIDATE_SOURCE)) {
                 $this->logger->debug('Dispatch VALIDATE_SOURCE event');
@@ -203,15 +204,15 @@ class Import implements ImportInterface
                 $event = $this->dispatcher->dispatch($event, ImportEvents::VALIDATE_SOURCE);
 
                 if (!$event->isValid()) {
-                    throw new ImportException(sprintf("The file '%s' is not valid", $file->getBasename()));
+                    throw new ImportException(sprintf("The file '%s' is not valid", $file->getPathname()));
                 }
             }
 
             if (($count = $this->loadData($resource, $file)) !== 0) {
                 $this->logger->notice('{file}: {count} lines loaded', [
                     'file' => $file->getBasename(),
-                    'count' => $count, ]
-                );
+                    'count' => $count,
+                ]);
                 $loaded = true;
             }
         }


### PR DESCRIPTION
## TLDR;
Improve error handling and debugging by knowing precisely which file to look at.

## Explanation

- Adds the resource path (instead of just the basename) to debug log entries, giving more context about which file is being loaded.
- When a file fails validation, the full path (via `getPathname()`) is now used in the `thrown ImportException`, instead of only the file’s basename.